### PR TITLE
Added meta information to resolved routes to include the original prismic metadata

### DIFF
--- a/lib/universal/src/public_api.ts
+++ b/lib/universal/src/public_api.ts
@@ -1,2 +1,3 @@
 export { getRoutes } from './routes';
-export { RouteConfig, DocTypeConfig, NgxPrismicExtraOptions } from './routes.model';
+export { PrismicRoute, RouteConfig, DocTypeConfig, NgxPrismicExtraOptions } from './routes.model';
+export { DocumentMetadata } from './prismic-uids';

--- a/lib/universal/src/routes.model.ts
+++ b/lib/universal/src/routes.model.ts
@@ -1,3 +1,5 @@
+import { DocumentMetadata } from './prismic-uids';
+
 /**
  * Defines the relationship between a Prismic custom type
  * and the associated path inside the Angular application.
@@ -23,6 +25,17 @@ export interface RouteConfig {
      */
     prismicApiUrl: string;
     docTypeConfigs: DocTypeConfig[];
+}
+
+export interface PrismicRoute {
+    /**
+     * The mapped route.
+     */
+    route: string;
+    /**
+     * Additional metadata.
+     */
+    meta: DocumentMetadata;
 }
 
 export interface NgxPrismicExtraOptions {


### PR DESCRIPTION
Added this information to resolved routes to provide more possibilities with the returned routes. For example, the `last_publication_date` of a document can be used for a sitemap.