### PR TITLE
uidMappingFunc can now also return an array of strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ speed-measure-plugin.json
 # misc
 /.sass-cache
 /connect.lock
-/coverage
+**/coverage
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/lib/universal/src/__mocks__/prismic-javascript.ts
+++ b/lib/universal/src/__mocks__/prismic-javascript.ts
@@ -40,7 +40,7 @@ function getApi(url): Promise<Partial<ResolvedApi>> {
                         alternate_languages: [
                             {
                                 id: 'XOlUGBAAAHc4IaRw',
-                                uid: 'home',
+                                uid: 'home-in-german',
                                 type: 'intro',
                                 lang: 'de-de'
                             }
@@ -50,7 +50,7 @@ function getApi(url): Promise<Partial<ResolvedApi>> {
                         last_publication_date: new Date().toISOString(),
                         href: 'https://google.com',
                         id: 'hiuads7623ohdas',
-                        uid: 'home',
+                        uid: 'home-in-english',
                         lang: 'en-gb',
                         slugs: [],
                         tags: [],

--- a/lib/universal/src/__mocks__/prismic-javascript.ts
+++ b/lib/universal/src/__mocks__/prismic-javascript.ts
@@ -1,0 +1,72 @@
+'use strict';
+
+import ResolvedApi from 'prismic-javascript/d.ts/ResolvedApi';
+import { Predicates } from 'prismic-javascript';
+import ApiSearchResponse from 'prismic-javascript/d.ts/ApiSearchResponse';
+
+const prismicJavascript: any = jest.genMockFromModule('prismic-javascript');
+
+function getApi(url): Promise<Partial<ResolvedApi>> {
+    const resolvedApi: Partial<ResolvedApi> = {
+        "refs": [
+            {
+                "id": "master",
+                "ref": "XNx5UhAAAIEEKH26",
+                "label": "Master",
+                "isMasterRef": true,
+                scheduledAt: null
+            }
+        ],
+        "bookmarks": {},
+        "types": {
+            "select_issue_example": "Select Issue Example"
+        },
+        "tags": [],
+        "experiments": {
+            drafts: [],
+            running: [],
+            current: null,
+            refFromCookie: null
+        },
+        query: () => {
+            // any because alternate_languages type is not consistent with what the API returns
+            const mockResponse: any = {
+                next_page: null,
+                prev_page: null,
+                page: 1,
+                total_pages: 2,
+                results: [
+                    {
+                        alternate_languages: [
+                            {
+                                id: 'XOlUGBAAAHc4IaRw',
+                                uid: 'home',
+                                type: 'intro',
+                                lang: 'de-de'
+                            }
+                        ],
+                        data: {},
+                        first_publication_date: new Date().toISOString(),
+                        last_publication_date: new Date().toISOString(),
+                        href: 'https://google.com',
+                        id: 'hiuads7623ohdas',
+                        uid: 'home',
+                        lang: 'en-gb',
+                        slugs: [],
+                        tags: [],
+                        type: 'intro'
+                    }
+                ]
+            };
+            return Promise.resolve(mockResponse);
+        }
+    };
+    return Promise.resolve(resolvedApi);
+}
+
+prismicJavascript.getApi = getApi;
+
+// Keep Predicates the way they are
+prismicJavascript.Predicates = Predicates;
+
+module.exports = prismicJavascript;

--- a/lib/universal/src/prismic-uids.spec.ts
+++ b/lib/universal/src/prismic-uids.spec.ts
@@ -1,0 +1,42 @@
+import * as Prismic from 'prismic-javascript';
+import { getPrismicUids } from './prismic-uids';
+import { Document } from 'prismic-javascript/d.ts/documents';
+
+describe('Prismic.getApi', () => {
+    it('should return a Promise', async () => {
+        const promise = Prismic.getApi('https://www.google.com');
+        expect(promise).toBeDefined();
+        expect(promise.then).toBeDefined();
+        expect(promise.catch).toBeDefined();
+    });
+    
+    it('should return a Promise with a resolved api', async () => {
+        const api = await Prismic.getApi('https://www.google.com');
+        expect(api).toBeDefined();
+        expect(api.refs).toBeDefined();
+        expect(api.refs[0].isMasterRef).toEqual(true);
+    });
+});
+
+describe('getPrismicUids', () => {
+    it('should return a Promise', async () => {
+        const promise = getPrismicUids('https://www.google.com', 'intro');
+        expect(promise).toBeDefined();
+        expect(promise.then).toBeDefined();
+        expect(promise.catch).toBeDefined();
+    });
+    it('should return with a resovled api response', async () => {
+        const result = (await getPrismicUids('https://www.google.com', 'intro')) as unknown as Document[];
+        expect(result).toBeDefined();
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].uid).toBeDefined();
+        expect(result[0].data).toBeUndefined();
+    });
+    it('should return with a resovled api response and data', async () => {
+        const result = (await getPrismicUids('https://www.google.com', 'intro', true)) as unknown as Document[];
+        expect(result).toBeDefined();
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].uid).toBeDefined();
+        expect(result[0].data).toBeDefined();
+    });
+});

--- a/lib/universal/src/routes.model.ts
+++ b/lib/universal/src/routes.model.ts
@@ -17,7 +17,7 @@ export interface DocTypeConfig {
      * Additionally, the complete document metadata can be used
      * to determine the route.
      */
-    uidMappingFunc: (uid: string, meta?: DocumentMetadata) => string;
+    uidMappingFunc: (uid: string, meta?: DocumentMetadata) => string | string[];
 }
 
 export interface RouteConfig {

--- a/lib/universal/src/routes.spec.ts
+++ b/lib/universal/src/routes.spec.ts
@@ -29,15 +29,38 @@ describe('getRoutes', () => {
     it('should return a promise with resolved routes', async () => {
         const routes = await getRoutes(config, options);
         expect(routes).toBeDefined();
-        expect(routes.length).toBeGreaterThan(0);
+        expect(routes.length).toEqual(2);
         expect(routes[0].route.includes('/home/')).toEqual(true);
+        expect(routes[0].route.includes('english')).toEqual(true);
+        expect(routes[1].route.includes('english')).toEqual(true);
+    });
+
+    it('should be able to process an array with one route', async () => {
+        config.docTypeConfigs[0].uidMappingFunc = (uid, meta) => {
+            return [`/mapped/${uid}`];
+        };
+        const routes = await getRoutes(config, options);
+        expect(routes).toBeDefined();
+        expect(routes.length).toEqual(2);
+        expect(routes[0].route.includes('/mapped/')).toEqual(true);
+        expect(routes[0].route.includes('english')).toEqual(true);
+        expect(routes[1].route.includes('english')).toEqual(true);
+    });
+
+    it('should be able to handle 0 mapped routes', async () => {
+        config.docTypeConfigs[0].uidMappingFunc = (uid, meta) => [];
+        const routes = await getRoutes(config, options);
+        expect(routes).toBeDefined();
+        expect(routes.length).toEqual(0);
     });
 
     it('should only contain metadata by default', async () => {
         const routes = await getRoutes(config, options);
         expect(routes).toBeDefined();
-        expect(routes.length).toBeGreaterThan(0);
+        expect(routes.length).toEqual(2);
         expect((routes[0].meta as any).data).toBeUndefined();
+        expect(routes[0].route.includes('english')).toEqual(true);
+        expect(routes[1].route.includes('english')).toEqual(true);
     });
 
     it('should contain the whole document', async () => {
@@ -45,7 +68,29 @@ describe('getRoutes', () => {
 
         const routes = await getRoutes(config, options);
         expect(routes).toBeDefined();
-        expect(routes.length).toBeGreaterThan(0);
+        expect(routes.length).toEqual(2);
         expect((routes[0].meta as any).data).toBeDefined();
+        expect(routes[0].route.includes('english')).toEqual(true);
+        expect(routes[1].route.includes('english')).toEqual(true);
+    });
+
+    it('should only be able to return multiple routes with mapper function', async () => {
+        config.docTypeConfigs[0].uidMappingFunc = (uid, meta) => {
+            const uids = [uid];
+            (meta.alternate_languages as any).forEach(al => uids.push(al.uid))
+            return uids.map(uid => `/myroute/${uid}`);
+        };
+
+        const routes = await getRoutes(config, options);
+        expect(routes).toBeDefined();
+        expect(routes.length).toEqual(4);
+        expect(routes[0].route.includes('/myroute/')).toEqual(true);
+        expect(routes[0].route.includes('english')).toEqual(true);
+        expect(routes[1].route.includes('/myroute/')).toEqual(true);
+        expect(routes[1].route.includes('german')).toEqual(true);
+        expect(routes[2].route.includes('/myroute/')).toEqual(true);
+        expect(routes[2].route.includes('english')).toEqual(true);
+        expect(routes[3].route.includes('/myroute/')).toEqual(true);
+        expect(routes[3].route.includes('german')).toEqual(true);
     });
 });

--- a/lib/universal/src/routes.spec.ts
+++ b/lib/universal/src/routes.spec.ts
@@ -1,0 +1,51 @@
+import { RouteConfig, NgxPrismicExtraOptions } from "./routes.model";
+import { getRoutes } from './routes';
+
+describe('getRoutes', () => {
+    let config: RouteConfig;
+    let options: NgxPrismicExtraOptions;
+    beforeEach(() => {
+        config = {
+            prismicApiUrl: 'https://www.google.com',
+            docTypeConfigs: [
+                {
+                    documentType: 'intro',
+                    uidMappingFunc: uid => `/home/${uid}`
+                }
+            ]
+        };
+        options = {
+            logFunc: message => undefined
+        };
+    });
+
+    it('should return a promise', async () => {
+        const promise = getRoutes(config, options);
+        expect(promise).toBeDefined();
+        expect(promise.then).toBeDefined();
+        expect(promise.catch).toBeDefined();
+    });
+
+    it('should return a promise with resolved routes', async () => {
+        const routes = await getRoutes(config, options);
+        expect(routes).toBeDefined();
+        expect(routes.length).toBeGreaterThan(0);
+        expect(routes[0].route.includes('/home/')).toEqual(true);
+    });
+
+    it('should only contain metadata by default', async () => {
+        const routes = await getRoutes(config, options);
+        expect(routes).toBeDefined();
+        expect(routes.length).toBeGreaterThan(0);
+        expect((routes[0].meta as any).data).toBeUndefined();
+    });
+
+    it('should contain the whole document', async () => {
+        config.includeDocumentData = true;
+
+        const routes = await getRoutes(config, options);
+        expect(routes).toBeDefined();
+        expect(routes.length).toBeGreaterThan(0);
+        expect((routes[0].meta as any).data).toBeDefined();
+    });
+});

--- a/lib/universal/src/routes.ts
+++ b/lib/universal/src/routes.ts
@@ -16,16 +16,37 @@ export async function getRoutes(config: RouteConfig, options = DEFAULT_EXTRA_OPT
     for (const docTypeConfig of config.docTypeConfigs) {
         const metaDocuments = await getPrismicUids(config.prismicApiUrl, docTypeConfig.documentType, config.includeDocumentData);
         const mappedRoutes = metaDocuments.map(doc => {
-            const prismicRoute: PrismicRoute = {
-                route: docTypeConfig.uidMappingFunc(doc.uid, doc),
+            let resolvedRouteOrRoutes = docTypeConfig.uidMappingFunc(doc.uid, doc);
+            if (!Array.isArray(resolvedRouteOrRoutes)) {
+                resolvedRouteOrRoutes = [resolvedRouteOrRoutes];
+            }
+
+            const resolvedRoutes: PrismicRoute[] = resolvedRouteOrRoutes.map(route => ({
+                route,
                 meta: doc
-            };
-            return prismicRoute;
+            }));
+
+            return resolvedRoutes;
         });
-        prismicRoutes.push(...mappedRoutes);
+        const flattenedMappedRoutes = flatten(mappedRoutes)
+        prismicRoutes.push(...flattenedMappedRoutes);
         options.logFunc(`Found ${mappedRoutes.length} routes for document type "${docTypeConfig.documentType}"`);
     }
 
     options.logFunc(`Found ${prismicRoutes.length} total routes\n`);
     return Promise.resolve(prismicRoutes);
 };
+
+/**
+ * Flattens an array up to the specified depth.
+ * 
+ * Use recursion, decrementing depth by 1 for each level of depth.
+ * Use Array.prototype.reduce() and Array.prototype.concat() to merge
+ * elements or arrays. Base case, for depth equal to 1 stops recursion.
+ * Omit the second argument, depth to flatten only to a depth of 1 (single flatten).
+ * 
+ * From: https://30secondsofcode.org/#flatten
+ */
+function flatten(arr, depth = 1) {
+    return arr.reduce((a, v) => a.concat(depth > 1 && Array.isArray(v) ? flatten(v, depth - 1) : v), []);
+}


### PR DESCRIPTION
This gives us the possibility to return multiple routes for one uid.

Example:
When querying by docType, only the UID of the "main" language is returned, with all other languages in the `alternateLanguages` array of the document. This means we need to resolve all other docs in the mapper function.